### PR TITLE
remove state requirement for auth

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -93,8 +93,8 @@ module OmniAuth
         error = request.params['error_reason'] || request.params['error']
         if error
           raise CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri'])
-        elsif request.params['state'].to_s.empty? || request.params['state'] != stored_state
-          return Rack::Response.new(['401 Unauthorized'], 401).finish
+        #elsif request.params['state'].to_s.empty? || request.params['state'] != stored_state
+        #  return Rack::Response.new(['401 Unauthorized'], 401).finish
         elsif !request.params["code"]
           return fail!(:missing_code, OmniAuth::OpenIDConnect::MissingCodeError.new(request.params["error"]))
         else


### PR DESCRIPTION
Authorization requires `state`, I'm using hybrid flow in my app, and so I don't care about state / have trouble passing it.

According to [RFC 6749](https://tools.ietf.org/html/rfc6749#section-4.1.1) state is only recommended. 

I'd like to use your gem, to keep up with the latest on security updates, but I need an option to ignore state.

What are the trade offs in not requiring it / is it something you would consider?

_Note: This PR isn't meant to be that feature, but to open the discussion._
